### PR TITLE
Allow main.go to work with the GitHub library

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"gitlab.com/waringer/broadlink/broadlinkrm"
+	"github.com/waringer/broadlink/broadlinkrm"
 )
 
 type cmdArguments struct {


### PR DESCRIPTION
Currently you have to modify main.go to work with the public GitHub library, this change fixes that.

Thanks again for the useful project!